### PR TITLE
Fixes issue #106 by preventing an exception from being thrown.

### DIFF
--- a/src/KTextView.m
+++ b/src/KTextView.m
@@ -57,6 +57,14 @@ static CGFloat kTextContainerYOffset = 0.0;
 - (void)mouseDown:(NSEvent*)event {
   NSPoint point = [self convertPoint:[event locationInWindow] fromView:nil];
   NSInteger charIndex = [self characterIndexForInsertionAtPoint:point];
+
+  // Prevent attributesAtIndex:effectiveRange: from throwing its exception
+  // by making sure we don't try to get the attributes for the last byte.
+  if (charIndex == [[self attributedString] length]) {
+    [super mouseDown: event];
+    return;
+  }
+
   NSRange effectiveRange;
   NSDictionary *attributes =
       [[self attributedString] attributesAtIndex:charIndex


### PR DESCRIPTION
-> http://hunch.lighthouseapp.com/projects/66522/tickets/106-enhancement-moving-cursor-to-end

Also considered changing charIndex to be 0-based (charIndex) but that does weird things to the attribute-related code further down and also moves the exception to the top of the file (first byte).
