### PR TITLE
Change of fonts (for readability purposes)

### DIFF
--- a/resources/style/default.css
+++ b/resources/style/default.css
@@ -1,7 +1,7 @@
 
 body {
-  font-family: "M+ 1m", monospace;
-  font-size: 11px;
+  font-family: "Monaco", monospace;
+  font-size: 12pt;
   background-color:#222;
   color: #eee;
 }

--- a/src/KDocument.mm
+++ b/src/KDocument.mm
@@ -83,10 +83,10 @@ static NSFont* _kDefaultFont = nil;
 
 + (NSFont*)defaultFont {
   if (!_kDefaultFont) {
-    _kDefaultFont = [[NSFont fontWithName:@"M+ 1m light" size:11.0] retain];
+    _kDefaultFont = [[NSFont fontWithName:@"Monaco" size:12.0] retain];
     if (!_kDefaultFont) {
-      WLOG("unable to find default font \"M+\" -- using system default");
-      _kDefaultFont = [[NSFont userFixedPitchFontOfSize:11.0] retain];
+      WLOG("unable to find default font \"Monaco\" -- using system default");
+      _kDefaultFont = [[NSFont userFixedPitchFontOfSize:12.0] retain];
     }
   }
   return _kDefaultFont;

--- a/src/KStyle.mm
+++ b/src/KStyle.mm
@@ -199,10 +199,10 @@ static NSString const *gDefaultElementSymbol;
   if (!baseFont_) {
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
     NSFont *font =
-        [fontManager fontWithFamily:@"M+ 1m" traits:0 weight:0 size:11.0];
+        [fontManager fontWithFamily:@"Monaco" traits:0 weight:0 size:12.0];
     if (!font) {
-      WLOG("unable to find default font \"M+\" -- using system default");
-      font = [NSFont userFixedPitchFontOfSize:11.0];
+      WLOG("unable to find default font \"Monaco\" -- using system default");
+      font = [NSFont userFixedPitchFontOfSize:12.0];
     }
     baseFont_ = [font retain];
   }
@@ -231,8 +231,7 @@ static NSString const *gDefaultElementSymbol;
     // Setup a new CSS context
     // Is the baseStylesheet really needed?
     CSSContext* cssContext =
-        [[CSSContext alloc] initWithStylesheet:[KStyle baseStylesheet]];
-    [cssContext addStylesheet:stylesheet];
+    [[CSSContext alloc] initWithStylesheet:stylesheet];
     kassert(cssContext);
     [stylesheet release]; // our local reference
     


### PR DESCRIPTION
The selected default font, "M+ 1m", is not readable for many people (see issue #93). The changes proposed in this pull request conform to a more standardized/readable "Monaco 12pt".
