### PR TITLE
Fix saving non existent files (issue #120)

### DIFF
--- a/src/KDocument.mm
+++ b/src/KDocument.mm
@@ -1771,7 +1771,7 @@ finishedReadingURL:(NSURL*)url
   NSURL *url = self.fileURL;
   KURLHandler *urlHandler =
       [[KDocumentController kodController] urlHandlerForURL:url];
-  return ( urlHandler && [urlHandler canWriteURL:url] );
+  return ( (urlHandler && [urlHandler canWriteURL:url]) || !url );
 }
 
 


### PR DESCRIPTION
Added a condition to the return statement of -canSaveDocument where if the URL is nil, it returns YES, since the file hasn't been saved to disk yet. Works as expected now.
