### PR TITLE
Autocomplete, first pass

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,3 +6,4 @@
 - August Joki <august.joki@gmail.com>
 - Swizec Teller <swizec@swizec.com>
 - Cody Krieger <cody@codykrieger.com>
+- Steve Johnson <steve.johnson.public@gmail.com>

--- a/src/KDocument.mm
+++ b/src/KDocument.mm
@@ -1223,6 +1223,8 @@ replacementString:(NSString *)replacementString {
     #endif
     sourceHighlighter_->cancel();
   }
+  
+  [textView_ updateAutocompleteForRange:range withString:replacementString];
 
   return YES;
 }

--- a/src/KTextView.h
+++ b/src/KTextView.h
@@ -10,6 +10,7 @@
   // kconf value "editor/text/indentation" (defaults to 2xSP)
   NSString *indentationString_;
   
+  // Frequency counts of all words used for autocomplete
   NSMutableDictionary *autocompleteWords_;
 }
 

--- a/src/KTextView.h
+++ b/src/KTextView.h
@@ -10,7 +10,7 @@
   // kconf value "editor/text/indentation" (defaults to 2xSP)
   NSString *indentationString_;
   
-  NSMutableSet *autocompleteWords_;
+  NSMutableDictionary *autocompleteWords_;
 }
 
 // The parent document

--- a/src/KTextView.h
+++ b/src/KTextView.h
@@ -9,6 +9,8 @@
 
   // kconf value "editor/text/indentation" (defaults to 2xSP)
   NSString *indentationString_;
+  
+  NSMutableSet *autocompleteWords_;
 }
 
 // The parent document

--- a/src/KTextView.h
+++ b/src/KTextView.h
@@ -40,4 +40,7 @@
 // Decrease the indentation level for the currently selected text
 - (void)decreaseIndentation;
 
+// When contents change, update the autocomplete dictionary
+- (void)updateAutocompleteForRange:(NSRange)range withString:(NSString *)replacementString;
+
 @end

--- a/src/KTextView.mm
+++ b/src/KTextView.mm
@@ -572,4 +572,22 @@ static CGFloat kTextContainerYOffset = 0.0;
   DLOG("cursorUpdate:%@", event);
 }*/
 
+
+#pragma mark -
+#pragma mark Autocomplete
+
+- (void)complete:(id)sender {
+  // TODO: Check for word boundary at cursor and ignore if no boundary
+  [super complete:sender];
+}
+
+- (NSArray *)completionsForPartialWordRange:(NSRange)charRange indexOfSelectedItem:(NSInteger *)index {
+  return [NSArray arrayWithObjects:@"aa", @"bb", @"cc", nil];
+}
+
+- (void)insertCompletion:(NSString *)word forPartialWordRange:(NSRange)charRange movement:(NSInteger)movement isFinal:(BOOL)flag {
+  [super insertCompletion:word forPartialWordRange:charRange movement:movement isFinal:flag];
+  [self setSelectedRange:NSMakeRange(charRange.location+charRange.length, [word length])];
+}
+
 @end

--- a/src/KTextView.mm
+++ b/src/KTextView.mm
@@ -677,7 +677,7 @@ static NSUInteger kAutocompleteProximitySearchDistance = 1024;
 - (void)complete:(id)sender {
   NSRange selectedRange = [self selectedRange];
   NSCharacterSet *irrelevantChars = [self irrelevantChars];
-  if (selectedRange.length == 0 && selectedRange.location > 0 && selectedRange.location < [[self layoutManager] numberOfGlyphs]-1) {
+  if (selectedRange.length == 0 && selectedRange.location > 0 && selectedRange.location < [[self string] length]-1) {
     NSString *surrounding = [[self attributedSubstringFromRange:NSMakeRange(selectedRange.location-1, 2)] string];
     BOOL leftIsSpace = [irrelevantChars characterIsMember:[surrounding characterAtIndex:0]];
     BOOL rightIsSpace = [irrelevantChars characterIsMember:[surrounding characterAtIndex:1]];

--- a/src/KTextView.mm
+++ b/src/KTextView.mm
@@ -675,6 +675,16 @@ static NSUInteger kAutocompleteProximitySearchDistance = 1024;
 
 // TODO: override default NSTextView behavior to not autocomplete if not at a word boundary
 - (void)complete:(id)sender {
+  NSRange selectedRange = [self selectedRange];
+  NSCharacterSet *irrelevantChars = [self irrelevantChars];
+  if (selectedRange.length == 0 && selectedRange.location > 0 && selectedRange.location < [[self layoutManager] numberOfGlyphs]-1) {
+    NSString *surrounding = [[self attributedSubstringFromRange:NSMakeRange(selectedRange.location-1, 2)] string];
+    BOOL leftOk = ![irrelevantChars characterIsMember:[surrounding characterAtIndex:0]];
+    BOOL rightOk = [irrelevantChars characterIsMember:[surrounding characterAtIndex:1]];
+    if (!(leftOk && rightOk)) {
+      return;
+    }
+  }
   [super complete:sender];
 }
 

--- a/src/KTextView.mm
+++ b/src/KTextView.mm
@@ -596,6 +596,11 @@ static NSUInteger kAutocompleteProximitySearchDistance = 1024;
   }
 }
 
+- (void)setString:(NSString *)string {
+  [super setString:string];
+  [self scanEntireFileForAutocompleteDictionary];
+}
+
 // Searches string within kAutocompleteProximitySearchDistance for occurrences of matching keywords
 // and puts the closest ones at the top. Keywords that do not appear closer than 1024 characters to
 // the cursor are unsorted and are listed after the sorted keywords.
@@ -687,7 +692,6 @@ static NSUInteger kAutocompleteProximitySearchDistance = 1024;
 
 // TODO: allow plugins to override default autocomplete results
 - (NSArray *)completionsForPartialWordRange:(NSRange)charRange indexOfSelectedItem:(NSInteger *)index {
-  [self scanEntireFileForAutocompleteDictionary];
   return [self completionsForPrefix:[[self string] substringWithRange:charRange] atPosition:charRange.location];
 }
 

--- a/src/KTextView.mm
+++ b/src/KTextView.mm
@@ -673,15 +673,15 @@ static NSUInteger kAutocompleteProximitySearchDistance = 1024;
   return [self sortedCompletions:completions forPrefix:prefix atPosition:position];
 }
 
-// TODO: override default NSTextView behavior to not autocomplete if not at a word boundary
+// Override default NSTextView behavior to not autocomplete if not at a word boundary
 - (void)complete:(id)sender {
   NSRange selectedRange = [self selectedRange];
   NSCharacterSet *irrelevantChars = [self irrelevantChars];
   if (selectedRange.length == 0 && selectedRange.location > 0 && selectedRange.location < [[self layoutManager] numberOfGlyphs]-1) {
     NSString *surrounding = [[self attributedSubstringFromRange:NSMakeRange(selectedRange.location-1, 2)] string];
-    BOOL leftOk = ![irrelevantChars characterIsMember:[surrounding characterAtIndex:0]];
-    BOOL rightOk = [irrelevantChars characterIsMember:[surrounding characterAtIndex:1]];
-    if (!(leftOk && rightOk)) {
+    BOOL leftIsSpace = [irrelevantChars characterIsMember:[surrounding characterAtIndex:0]];
+    BOOL rightIsSpace = [irrelevantChars characterIsMember:[surrounding characterAtIndex:1]];
+    if (leftIsSpace == rightIsSpace) {
       return;
     }
   }


### PR DESCRIPTION
KTextView has been modified to have an `autocompleteWords_` dictionary which contains frequency counts of all words in the document (where a 'word' is a string of characters not in an NSCharacterSet defined in irrelevantChars).

When Escape is pressed, the standard Cocoa autocomplete system displays a popup with a list provided by the KTextView subclass. This list is obtained by iterating over `autocompleteWords_`'s keys and appending keys (words) that have the current word as a prefix. They are then sorted according to these criteria:
- Words that appear closer than 1024 characters are sorted by proximity to the cursor (using an NSScanner)
- Other matches are sorted by how many times they appear in the document

The autocomplete menu does not appear unless the cursor is at a word boundary.

Possible improvements which can be ignored if this implementation is Good Enough:
- Better string storage. Technically a trie would be the most efficient. (I have experience implementing them in other languages.)
- Faster word proximity scanning, which would allow more of the document to be searched. I felt that a limited proximity search was acceptable since if a user cannot see the word on the screen, he probably doesn't care about where it appears in the sort order.
- Style the text in the popup. Not sure how possible this is.
- Test, test, test!
