### PR TITLE
Make Kod remember what language it was showing after saving a file

### DIFF
--- a/src/KDocument.mm
+++ b/src/KDocument.mm
@@ -1830,6 +1830,7 @@ finishedReadingURL:(NSURL*)url
       if (!langId_) {
         // implies queueing of complete highlighting
         [self guessLanguageBasedOnUTI:typeName textContent:text];
+
       } else {
         if (isVisible_)
           [self setNeedsHighlightingOfCompleteDocument];
@@ -1950,8 +1951,14 @@ finishedReadingURL:(NSURL*)url
       // Guess syntax
       if (highlightingEnabled_) {
         // TODO: typeName might have changed during reading
-        [self guessLanguageBasedOnUTI:typeName
-                          textContent:self.textView.string];
+
+        // Turn typeName (php) back into UTI (public.php-script)
+
+        NSString *uti = nil;
+        [absoluteURL getResourceValue:&uti forKey:NSURLTypeIdentifierKey error:nil];
+
+        [self guessLanguageBasedOnUTI:uti
+                          textContent:self.textView.string];        
       }
     }
 


### PR DESCRIPTION
In some cases, specifically when dealing with PHP files, Kod would forget what language it was highlighting and would default back to 'html'. This change makes sure it will rehighlight as (in my case) PHP. Fix seems to be supplying an actual UTI (public.php-script) instead of the fileType (php). 
