### PR TITLE
Support for HTTPS URLs

### DIFF
--- a/src/KDocumentController.mm
+++ b/src/KDocumentController.mm
@@ -50,6 +50,7 @@
     // register built-in URL handlers
     [urlHandlers_ setObject:[KFileURLHandler handler] forKey:@"file"];
     [urlHandlers_ setObject:[KHTTPURLHandler handler] forKey:@"http"];
+	[urlHandlers_ setObject:[KHTTPURLHandler handler] forKey:@"https"];
     [urlHandlers_ setObject:[KKodURLHandler handler] forKey:@"kod"];
   }
   return self;

--- a/src/KHTTPURLHandler.mm
+++ b/src/KHTTPURLHandler.mm
@@ -1,11 +1,12 @@
 #import "common.h"
 #import "KHTTPURLHandler.h"
+#import "NSStringICUAdditions.h"
 
 @implementation KHTTPURLHandler
 
 
 - (BOOL)canReadURL:(NSURL*)url {
-  return [[url scheme] caseInsensitiveCompare:@"http"] == NSOrderedSame;
+  return [[url scheme] matchesPattern:@"https?"];
 }
 
 


### PR DESCRIPTION
At the moment Kod won't load https urls, complaining:

```
Unsupported URI scheme 'https'
```

To fix I've set KHTTPURLHandler as the handler to be used for https (in addition to http) urls.
