### PR TITLE
Custom font

### DIFF
--- a/src/KDocument.mm
+++ b/src/KDocument.mm
@@ -86,9 +86,9 @@ static NSFont* _kDefaultFont = nil;
 
 + (NSFont*)defaultFont {
   if (!_kDefaultFont) {
-    _kDefaultFont = [[NSFont fontWithName:@"M+ 1m light" size:11.0] retain];
+    _kDefaultFont = [[[KStyle sharedStyle] baseFont] retain];
     if (!_kDefaultFont) {
-      WLOG("unable to find default font \"M+\" -- using system default");
+      WLOG("unable to find default font from CSS -- using system default");
       _kDefaultFont = [[NSFont userFixedPitchFontOfSize:11.0] retain];
     }
   }

--- a/src/KStyle.mm
+++ b/src/KStyle.mm
@@ -197,11 +197,10 @@ static NSString const *gDefaultElementSymbol;
 
 - (NSFont*)baseFont {
   if (!baseFont_) {
-    NSFontManager *fontManager = [NSFontManager sharedFontManager];
-    NSFont *font =
-        [fontManager fontWithFamily:@"M+ 1m" traits:0 weight:0 size:11.0];
+    CSSStyle *bodyStyle = [self styleForElementName: gDefaultElementSymbol];
+    NSFont *font = [bodyStyle font];
     if (!font) {
-      WLOG("unable to find default font \"M+\" -- using system default");
+      WLOG("unable to find any of the specified fonts -- using system default");
       font = [NSFont userFixedPitchFontOfSize:11.0];
     }
     baseFont_ = [font retain];


### PR DESCRIPTION
Support for specifying custom font family, size, and weight in the CSS file. Handles missing CSS declarations, missing fonts by falling back to system defaults thanks to CSSStyle.

![Comic Sans in action](http://f.cl.ly/items/2O1I1K3W0j1l0j0j0I1R/Schermata%202011-01-06%20a%2013.28.08.png)
