### PR TITLE
Kod helper wait param

### DIFF
--- a/src/KDocument.h
+++ b/src/KDocument.h
@@ -43,6 +43,8 @@ extern NSString *const KDocumentDidLoadDataNotification;
 
   // Internal state
   hatomic_flags_t stateFlags_;
+  
+  NSInvocation *closeCallback_;
 }
 
 @property(assign, nonatomic) BOOL isDirty;
@@ -65,6 +67,7 @@ extern NSString *const KDocumentDidLoadDataNotification;
 // during a session (between starting and terminating Kod.app).
 @property(readonly) uint64_t identifier;
 
+@property(retain) NSInvocation *closeCallback;
 
 /*!
  * Monotonically incrementing version number which changes for each edit.

--- a/src/KDocument.mm
+++ b/src/KDocument.mm
@@ -26,6 +26,7 @@
 #import "node-module/ASTNodeWrapper.h"
 #import "KASTViewerWindowController.h"
 #import "KASTViewerController.h"
+#import "KMachService-NSInvocation.h"
 
 #import "NSImage-kod.h"
 #import "CIImage-kod.h"
@@ -88,7 +89,8 @@ static uint64_t KDocumentNextIdentifier() {
 
 @synthesize textEncoding = textEncoding_,
             textView = textView_,
-            ast = ast_;
+            ast = ast_,
+            closeCallback = closeCallback_;
 
 static NSImage* _kDefaultIcon = nil;
 static NSString* _kDefaultTitle = @"Untitled";
@@ -174,6 +176,8 @@ static NSString* _kDefaultTitle = @"Untitled";
 
   // register as text storage delegate
   textView_.textStorage.delegate = self;
+  
+  closeCallback_ = nil;
 
   return self;
 }
@@ -560,6 +564,8 @@ static NSString* _kDefaultTitle = @"Untitled";
   }
   [[NSDocumentController sharedDocumentController] removeDocument:self];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+  
+  [closeCallback_ invokeKMachServiceCallbackWithArgument:nil];
 }
 
 

--- a/src/KDocumentController.h
+++ b/src/KDocumentController.h
@@ -48,12 +48,24 @@ withWindowController:(KBrowserWindowController*)windowController
                    withWindowController:(KBrowserWindowController*)windowController
                                priority:(long)priority
          nonExistingFilesAsNewDocuments:(BOOL)newDocForNewURLs
+                         closeCallbacks:(NSArray*)closeCallbacks
                                callback:(void(^)(NSError*))callback;
+
+- (void)openDocumentsWithContentsOfURLs:(NSArray*)urls
+                  withWindowController:(KBrowserWindowController*)windowController
+                              priority:(long)priority
+        nonExistingFilesAsNewDocuments:(BOOL)newDocForNewURLs
+                              callback:(void(^)(NSError*))callback;
 
 // Open |urls| in frontmost window with high priority
 - (void)openDocumentsWithContentsOfURLs:(NSArray*)urls
          nonExistingFilesAsNewDocuments:(BOOL)newDocForNewURLs
+                         closeCallbacks:(NSArray*)closeCallbacks
                                callback:(void(^)(NSError*))callback;
+
+- (void)openDocumentsWithContentsOfURLs:(NSArray*)urls
+        nonExistingFilesAsNewDocuments:(BOOL)newDocForNewURLs
+                              callback:(void(^)(NSError*))callback;
 
 // Open |urls| in frontmost window with high priority
 - (void)openDocumentsWithContentsOfURLs:(NSArray*)urls

--- a/src/KMachServiceProtocol.h
+++ b/src/KMachServiceProtocol.h
@@ -6,10 +6,13 @@
 
 @protocol KMachServiceProtocol
 
-- (void)openURLs:(NSArray*)absoluteURLStrings callback:(NSInvocation*)callback;
+- (void)openURLs:(NSArray*)absoluteURLStrings 
+  closeCallbacks:(NSArray*)closeCallbacks
+   errorCallback:(NSInvocation*)errorCallback;
 
 - (void)openNewDocumentWithData:(NSData*)data
                          ofType:(NSString*)typeName
-                       callback:(NSInvocation*)callback;
+                  closeCallback:(NSInvocation*)callback
+                  errorCallback:(NSInvocation*)callback;
 
 @end

--- a/src/kod_helper.h
+++ b/src/kod_helper.h
@@ -14,6 +14,7 @@
   NSMutableDictionary *asyncWaitQueue_;
   BOOL forceReadStdin_; // true if a "-" is passed in argv
   int optNoWaitOpen_; // 1 if -n or --nowait-open
+  int optWaitForDocumentClose; // 1 if -w or --wait
 }
 
 @property(readonly) NSRunningApplication *kodApp;


### PR DESCRIPTION
Hello Rasmus, here's a patch which adds a -w (--wait) parameter to the kod command line helper. It makes it wait for all the passed documents to be closed in Kod before exiting.

This implements Lighthouse ticket #185.
