### PR TITLE
Reload filetree after save

### DIFF
--- a/src/KBrowserWindowController.h
+++ b/src/KBrowserWindowController.h
@@ -31,4 +31,5 @@
 
 - (BOOL)openFileDirectoryAtURL:(NSURL *)absoluteURL error:(NSError **)outError;
 
+- (BOOL)reopenDirectoryIfOpen;
 @end

--- a/src/KBrowserWindowController.mm
+++ b/src/KBrowserWindowController.mm
@@ -261,7 +261,6 @@
   return y;
 }
 
-
 #pragma mark -
 #pragma mark Notifications
 
@@ -433,6 +432,14 @@ willPositionSheet:(NSWindow *)sheet
   if (success) {
     // make sure the sidebar is visible
     splitView_.isCollapsed = NO;
+  }
+}
+
+- (BOOL)reopenDirectoryIfOpen {
+  NSURL *absoluteURL = ((KToolbarController *)toolbarController_).directoryURL;
+  if (absoluteURL) {
+    NSError *error = nil;
+    return [self openFileDirectoryAtURL:absoluteURL error:&error];
   }
 }
 

--- a/src/KDocument.mm
+++ b/src/KDocument.mm
@@ -1742,6 +1742,10 @@ finishedReadingURL:(NSURL*)url
       // TODO(rsms): guess syntax/language
     }
 
+    // We need to reload the file tree in the sidebar, because we may have
+    // created a new file (if it was "saved as").
+    [self.windowController reopenDirectoryIfOpen];
+
     // unfreeze tab
     if (tabWasEditable)
       self.isEditable = YES;

--- a/src/KFileTreeController.mm
+++ b/src/KFileTreeController.mm
@@ -157,7 +157,6 @@ static NSString *kNameColumnId = @"name";
   });
 }*/
 
-
 #pragma mark -
 #pragma mark NSOutlineViewDataSource methods
 


### PR DESCRIPTION
If you "save as", the new copy of the file doesn't show up in the file tree in the sidebar.  This commit fixes that.
