### PR TITLE
Fix indent bindings

### DIFF
--- a/src/KTextView.mm
+++ b/src/KTextView.mm
@@ -366,10 +366,12 @@ static NSColor *kColumnGuideColor = nil, *kColumnGuideBackgroundColor = nil;
 // return nil for "I handled this"
 - (NSEvent*)filterInputEvent:(NSEvent*)event {
 
-  // XXX bind alt+rightwardsarrow to "indent"
+  // Bind cmd+] and cmd+[ to indent and de-indent, respectively.
   static BOOL debugDidSet = NO; if (!debugDidSet) { debugDidSet = YES;
-    KInputBindings::set(KInputBindings::TextEditorLevel, @"A-<right>",
+    KInputBindings::set(KInputBindings::TextEditorLevel, @"M-]",
         new KSelectorInputAction(@selector(increaseIndentation)));
+    KInputBindings::set(KInputBindings::TextEditorLevel, @"M-[",
+        new KSelectorInputAction(@selector(decreaseIndentation)));
   }
   KInputAction *action =
       KInputBindings::get(KInputBindings::TextEditorLevel, event);


### PR DESCRIPTION
Right now, the binding for indent lines is alt+right.  This is bad, as it breaks Mac OS's text navigation bindings (alt+left and alt+right navigate by a single word).  This removes that binding and adds cmd+] and cmd+[ for indenting/de-indenting, respectively.  This is consistent with other text editors on like Xcode and Textmate.
