### PR TITLE
Update node submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/rsms/hunch-cocoa.git
 [submodule "deps/node"]
 	path = deps/node
-	url = https://github.com/ry/node.git
+	url = https://github.com/joyent/node.git
 [submodule "deps/chromium-tabs"]
 	path = deps/chromium-tabs
 	url = https://github.com/rsms/chromium-tabs.git


### PR DESCRIPTION
The ry/node repository was moved to joyent/node on 2011-02-23.  This commit updates .gitmodules accordingly.  I noticed there is a rsms fork of node, but it appears to be fairly out-of-date, so I opted for the joyent repo.
