### PR TITLE
XCode4 search path for CSS.h fix

### DIFF
--- a/kod.xcodeproj/project.pbxproj
+++ b/kod.xcodeproj/project.pbxproj
@@ -1647,6 +1647,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3AA91E5D12C95CC000132A25 /* debug.xcconfig */;
 			buildSettings = {
+				LIBCSS_HEADER_SEARCH_PATHS = "\"deps/libcss/cocoa-framework/build/$(BUILD_STYLE)/CSS.framework/Headers\" \"deps/libcss/include\"";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/build/Debug/gazelle\"",
@@ -1658,6 +1659,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3AA91E5E12C95CC000132A25 /* release.xcconfig */;
 			buildSettings = {
+				LIBCSS_HEADER_SEARCH_PATHS = "\"deps/libcss/cocoa-framework/build/$(BUILD_STYLE)/CSS.framework/Headers\" \"deps/libcss/include\"";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/build/Debug/gazelle\"",


### PR DESCRIPTION
Added search path for XCode to find csslib headers. Is /include the new /headers?

Together with https://github.com/rsms/chromium-tabs/pull/5, I believe this fixes #52 (at least, it does for me).
