### PR TITLE
there were some issues with asking the user on a dirty document to save i

### DIFF
--- a/src/KBrowser.mm
+++ b/src/KBrowser.mm
@@ -52,15 +52,7 @@
 // Overriding CTBrowser's -closeTab in order to check if the document is
 // dirty or not before closing.
 - (void)closeTab {
-  KDocument *doc = (KDocument *)[self tabContentsAtIndex:[self selectedTabIndex]];
-
-  if ([doc isDirty]) {
-    [doc canCloseDocumentWithDelegate:self shouldCloseSelector:@selector(document:shouldClose:contextInfo:) contextInfo:nil];
-  } else {
-    shouldCloseTab = YES;
-    [super closeTab];
-  }
-
+  shouldCloseTab = NO;
 }
 
 
@@ -69,12 +61,31 @@
      shouldClose:(BOOL)shouldClose
      contextInfo:(void*)contextInfo {
   shouldCloseTab = shouldClose;
-  [super closeTab];
+
+  if ( shouldClose ) {
+    [super closeTab];
+  }
 }
 
 
 // Overriding CTBrowser's implementation, which always returns YES
 - (BOOL)canCloseTab {
+  return shouldCloseTab;
+}
+
+- (BOOL)canCloseContentsAt:(int)index {
+  if ( shouldCloseTab == YES ) {
+    return shouldCloseTab;
+  }
+
+  KDocument *doc = (KDocument *)[self tabContentsAtIndex:index];
+
+  if ([doc isDirty]) {
+    [doc canCloseDocumentWithDelegate:self shouldCloseSelector:@selector(document:shouldClose:contextInfo:) contextInfo:nil];
+  } else {
+    shouldCloseTab = YES;
+  }
+
   return shouldCloseTab;
 }
 


### PR DESCRIPTION
there were some issues with asking the user on a dirty document to save it
most of the time it wasn't asking until you quit the app

this change now asks the user on closing a dirty tab if he wants to save, discard changes and close anyway or leave the tab open and handles the response properly.
